### PR TITLE
Fix alternative site determination

### DIFF
--- a/pyascore/ptm_scoring/cpp/Ascore.cpp
+++ b/pyascore/ptm_scoring/cpp/Ascore.cpp
@@ -218,25 +218,25 @@ namespace ptmscoring {
             if ( ndifferences != 1 ) continue;
 
             size_t same_count = 0;
-            size_t best_pos = 0;
-            size_t comp_pos = 0;
+            size_t ascore_ind = 0;
+            size_t comp_sig_ind = 0;
             std::vector<size_t>::iterator best_it = best_score.signature.begin();
             std::vector<size_t>::iterator comp_it = competing_score.signature.begin();
             for (; best_it < best_score.signature.end(); best_it++, comp_it++) {
                 if (*best_it and *comp_it) {
                     same_count++;
                 } else if (*best_it and not *comp_it) {
-                    best_pos = same_count;
+                    ascore_ind = same_count;
                 } else if (not *best_it and *comp_it) {
-                    comp_pos = same_count;
+                    comp_sig_ind = comp_it - competing_score.signature.begin();
                 }
             }
 
-            AscoreContainer & cont = ascore_containers_.at(best_pos);
+            AscoreContainer & cont = ascore_containers_.at(ascore_ind);
             if (cont.ascores.empty() || 
                 competing_score.weighted_score == cont.pep_scores.back() ) {
                 cont.competing_index.push_back(
-                    modified_peptide_ptr->getPosOfNthModifiable(comp_pos) + 1 
+                    modified_peptide_ptr->getPosOfNthModifiable(comp_sig_ind) + 1 
                 );
                 cont.pep_scores.push_back( 
                     competing_score.weighted_score 
@@ -246,7 +246,7 @@ namespace ptmscoring {
                 );
             }
 
-        }   
+        }
     }
 
     void Ascore::score (const BinnedSpectra & binned_spectra, 

--- a/test/test_ascore.py
+++ b/test/test_ascore.py
@@ -1,6 +1,7 @@
 import unittest
 import time
 import os
+import re
 import pickle
 import numpy as np
 from pyascore import PyAscore
@@ -57,3 +58,38 @@ class TestPyAscore(unittest.TestCase):
         test_match_pairs("velos_matches_3_mods.pkl", "velos_spectra_3_mods.pkl")
         test_match_pairs("dump_match.pkl", "dump_spectra.pkl")
         test_match_pairs("velos_matches_aux.pkl", "velos_spectra_aux.pkl")
+
+    def test_alternative_site_consistency(self):
+        ascore = PyAscore(bin_size=100., n_top=10,
+                          mod_group="STY", mod_mass=79.966331)
+        def test_consistency(match_file, spec_file):
+            with open(os.path.join("test", "match_spectra_pairs", match_file), "rb") as src:
+                match_list = pickle.load(src)
+
+            with open(os.path.join("test", "match_spectra_pairs", spec_file), "rb") as src:
+                spectra_list = pickle.load(src)
+
+            for match, spectra in zip(match_list, spectra_list):
+                ascore = PyAscore(bin_size=100., n_top=10,
+                                  mod_group="STY", mod_mass=79.966331)
+                ascore.score(spectra["mz_values"],
+                             spectra["intensity_values"],
+                             match["peptide"],
+                             len(match["mod_positions"]))
+
+                # Alternative sites should be free of duplicates
+                for alt in ascore.alt_sites:
+                    n_alt_sites = alt.shape[0]
+                    n_deduplicated = np.unique(alt).shape[0]
+                    self.assertEqual(n_alt_sites, n_deduplicated)
+
+                # No modified sites should show up in alternative sites
+                site_iter = re.finditer("[A-Z][^A-Z]*", ascore.best_sequence)
+                modified_sites = [ind + 1 for ind, m in enumerate(site_iter) if "[80]" in m.group()]
+                alt_sites = np.concatenate(ascore.alt_sites)
+                n_overlapping_sites = np.intersect1d(modified_sites, alt_sites).shape[0]
+                self.assertEqual(n_overlapping_sites, 0)
+
+        test_consistency("velos_matches_1_mods.pkl", "velos_spectra_1_mods.pkl")
+        test_consistency("velos_matches_2_mods.pkl", "velos_spectra_2_mods.pkl")
+        test_consistency("velos_matches_3_mods.pkl", "velos_spectra_3_mods.pkl")


### PR DESCRIPTION
This PR is to address a bug in the reporting of alternative sites for a given a localization that was reported in #4. The error stems from a miss-assignment of a variable when attempting to determine where exactly an alternative localization differs from the best localization. This bug does not appear to affect the PepScore or the Ascores reported, only the position of the alternative sites.

- [x] Fix reported alternative sites
- [x] Improve test coverage for alternative sites