### PR TITLE
All Python API access to PepScores and Ambiguity scores

### DIFF
--- a/pyascore/ptm_scoring/Ascore.pxd
+++ b/pyascore/ptm_scoring/Ascore.pxd
@@ -7,10 +7,19 @@ cdef extern from "cpp/Ascore.cpp":
     pass
 
 cdef extern from "cpp/Ascore.h" namespace "ptmscoring":
+    cdef struct ScoreContainer:
+        vector[size_t] signature;
+        vector[size_t] counts;
+        vector[float] scores;
+        float weighted_score;
+        size_t total_fragments;
+
     cdef cppclass Ascore:
-        Ascore() except +
-        void score(const BinnedSpectra &, const ModifiedPeptide &)
-        string getBestSequence()
-        float getBestScore()
+        Ascore() except +;
+        void score(const BinnedSpectra &, const ModifiedPeptide &);
+        string getBestSequence();
+        vector[string] getAllSequences();
+        float getBestScore();
+        vector[ScoreContainer] getAllPepScores();
         vector[float] getAscores();
         vector[size_t] getAlternativeSites(size_t);

--- a/pyascore/ptm_scoring/Ascore.pxd
+++ b/pyascore/ptm_scoring/Ascore.pxd
@@ -17,6 +17,7 @@ cdef extern from "cpp/Ascore.h" namespace "ptmscoring":
     cdef cppclass Ascore:
         Ascore() except +;
         void score(const BinnedSpectra &, const ModifiedPeptide &);
+        float calculateAmbiguity(const ScoreContainer&, const ScoreContainer&);
         string getBestSequence();
         vector[string] getAllSequences();
         float getBestScore();

--- a/pyascore/ptm_scoring/Ascore.pyx
+++ b/pyascore/ptm_scoring/Ascore.pyx
@@ -3,7 +3,7 @@ import cython
 import numpy as np
 cimport numpy as np
 
-from Ascore cimport Ascore
+from Ascore cimport Ascore, ScoreContainer
 from ModifiedPeptide cimport ModifiedPeptide
 from Spectra cimport BinnedSpectra
 
@@ -128,6 +128,33 @@ cdef class PyAscore:
     @property
     def best_score(self):
         return self.ascore_ptr[0].getBestScore()
+
+    @property
+    def pep_scores(self):
+        cdef vector[ScoreContainer] raw_score_conts = self.ascore_ptr[0].getAllPepScores();
+        cdef vector[string] sequences = self.ascore_ptr[0].getAllSequences();
+
+        proc_score_conts = []
+        cdef size_t i, j
+        for i in range(raw_score_conts.size()):
+            score_cont = {}
+
+            score_cont["signature"] = []
+            for j in range(raw_score_conts[i].signature.size()):
+                score_cont["signature"].append(raw_score_conts[i].signature[j])
+
+            score_cont["counts"] = []
+            score_cont["scores"] = []
+            for j in range(raw_score_conts[i].counts.size()):
+                score_cont["counts"].append(raw_score_conts[i].counts[j])
+                score_cont["scores"].append(raw_score_conts[i].scores[j])
+
+            score_cont["weighted_score"] = raw_score_conts[i].weighted_score
+            score_cont["total_fragments"] = raw_score_conts[i].total_fragments
+            score_cont["sequence"] = sequences[i]
+            proc_score_conts.append(score_cont)
+
+        return proc_score_conts;
 
     @property
     def ascores(self):

--- a/pyascore/ptm_scoring/Ascore.pyx
+++ b/pyascore/ptm_scoring/Ascore.pyx
@@ -45,7 +45,11 @@ cdef class PyAscore:
     best_sequence : str
         Peptide sequence with modifications included in brackets for the best scoring localization.
     best_score : float
-        The best Pep score among all possible localization permutations.
+        The best PepScore among all possible localization permutations.
+    pep_scores : list of dict
+        Python dict representations of internal PepScore objects. Each object contains the sequence
+        of the underlying peptide and all information necessary to calculate the ambiguity scores.
+        The list is sorted by decreasing weighted_score which is also known as the PepScore.
     ascores : ndarray of float32
         Ascores for each individual non-static site in the peptide.
     alt_sites : list of ndarry of uint32
@@ -79,7 +83,7 @@ cdef class PyAscore:
                     str peptide, size_t n_of_mod,
                     np.ndarray[np.uint32_t, ndim=1, mode="c"] aux_mod_pos = None,
                     np.ndarray[np.float32_t, ndim=1, mode="c"] aux_mod_mass = None):
-        """Consumer spectra and associated peptide information and score PTM localization
+        """Consume spectra and associated peptide information and score PTM localization
 
         Parameters
         ----------
@@ -162,6 +166,24 @@ cdef class PyAscore:
         return cont
 
     def calculate_ambiguity(self, dict ref_score, dict other_score):
+        """Calculate ambiguity between 2 competing localizations
+
+        Inputs to this function should come directly from the pep_scores attribute.
+        For this score to be possitive, the score dict with the highest weighted_score
+        should come first. When the weighted_score for both is equal, this will return 0.
+
+        Parameters
+        ----------
+        ref_score : dict
+            PepScore object for one localization.
+        other_score : dict
+            PepScore object for competing localization.
+
+        Returns
+        -------
+        float
+            The ambiguity score (ascore) between 2 localizations
+        """
         cdef ScoreContainer ref_score_cont = self._pyobj_to_score_cont(ref_score)
         cdef ScoreContainer other_score_cont = self._pyobj_to_score_cont(other_score)
 

--- a/pyascore/ptm_scoring/cpp/Ascore.cpp
+++ b/pyascore/ptm_scoring/cpp/Ascore.cpp
@@ -273,11 +273,27 @@ namespace ptmscoring {
         }
     }
 
+    std::vector<std::string> Ascore::getAllSequences () {
+        std::vector<std::string> sequences;
+        for (ScoreContainer cont : peptide_scores_) {
+            sequences.push_back(modified_peptide_ptr->getPeptide(cont.signature));
+        }
+        return sequences;
+    }
+
     float Ascore::getBestScore () {
         if ( peptide_scores_.size() ) {
             return peptide_scores_.front().weighted_score;
         } else {
             return -1;
+        }
+    }
+
+    std::vector<ScoreContainer> Ascore::getAllPepScores () {
+        if ( peptide_scores_.size() ) {
+            return peptide_scores_;
+        } else {
+            return {};
         }
     }
 

--- a/pyascore/ptm_scoring/cpp/Ascore.h
+++ b/pyascore/ptm_scoring/cpp/Ascore.h
@@ -10,6 +10,21 @@
 
 namespace ptmscoring {
 
+    struct ScoreContainer {
+        std::vector<size_t> signature;
+        std::vector<size_t> counts;
+        std::vector<float> scores;
+        float weighted_score = -1;
+        size_t total_fragments;
+    };
+
+    struct AscoreContainer {
+        size_t sig_pos; // Position within signature of reference
+        std::vector<size_t> competing_index; // Position within peptide of competing modifiable amino acids
+        std::vector<float> pep_scores; // Pepscore for competing modifiable amino acids
+        std::vector<float> ascores; // Ascores of reference vs other modifiable amino acids
+    };
+
     class Ascore {
         BinomialDist bin_dist;
         const BinnedSpectra * binned_spectra_ptr;
@@ -18,21 +33,7 @@ namespace ptmscoring {
         std::vector<float> score_weights;
         std::vector<BinomialDist> scoring_distributions;
 
-        struct ScoreContainer {
-            std::vector<size_t> signature;
-            std::vector<size_t> counts;
-            std::vector<float> scores;
-            float weighted_score = -1;
-            size_t total_fragments;
-        };
         std::vector<ScoreContainer> peptide_scores_;
-
-        struct AscoreContainer {
-            size_t sig_pos; // Position within signature of reference
-            std::vector<size_t> competing_index; // Position within peptide of competing modifiable amino acids
-            std::vector<float> pep_scores; // Pepscore for competing modifiable amino acids
-            std::vector<float> ascores; // Ascores of reference vs other modifiable amino acids
-        };
         std::vector<AscoreContainer> ascore_containers_;
 
         void resetInternalState();
@@ -49,7 +50,9 @@ namespace ptmscoring {
 
             void score(const BinnedSpectra &, const ModifiedPeptide &);
             std::string getBestSequence();
+            std::vector<std::string> getAllSequences();
             float getBestScore();
+            std::vector<ScoreContainer> getAllPepScores();
             std::vector<float> getAscores();
             std::vector<size_t> getAlternativeSites(size_t);
     };

--- a/pyascore/ptm_scoring/cpp/Ascore.h
+++ b/pyascore/ptm_scoring/cpp/Ascore.h
@@ -42,13 +42,13 @@ namespace ptmscoring {
         void sortScores();
         bool isUnambiguous();
         void findModifiedPos();
-        float calculateAmbiguity(const ScoreContainer&, const ScoreContainer&);
         void calculateAscores();
         public:
             Ascore();
             ~Ascore();
 
             void score(const BinnedSpectra &, const ModifiedPeptide &);
+            float calculateAmbiguity(const ScoreContainer&, const ScoreContainer&);
             std::string getBestSequence();
             std::vector<std::string> getAllSequences();
             float getBestScore();

--- a/test/test_ascore.py
+++ b/test/test_ascore.py
@@ -129,3 +129,35 @@ class TestPyAscore(unittest.TestCase):
         test_return("velos_matches_1_mods.pkl", "velos_spectra_1_mods.pkl")
         test_return("velos_matches_2_mods.pkl", "velos_spectra_2_mods.pkl")
         test_return("velos_matches_3_mods.pkl", "velos_spectra_3_mods.pkl")
+
+    def test_ambiguity(self):
+        ascore = PyAscore(bin_size=100., n_top=10,
+                          mod_group="STY", mod_mass=79.966331)
+        def test_ambiguity(match_file, spec_file):
+            with open(os.path.join("test", "match_spectra_pairs", match_file), "rb") as src:
+                match_list = pickle.load(src)
+
+            with open(os.path.join("test", "match_spectra_pairs", spec_file), "rb") as src:
+                spectra_list = pickle.load(src)
+
+            for match, spectra in zip(match_list, spectra_list):
+                ascore = PyAscore(bin_size=100., n_top=10,
+                                  mod_group="STY", mod_mass=79.966331)
+                ascore.score(spectra["mz_values"],
+                             spectra["intensity_values"],
+                             match["peptide"],
+                             len(match["mod_positions"]))
+
+                pep_scores = ascore.pep_scores
+                self.assertEqual(
+                    ascore.calculate_ambiguity(pep_scores[0], pep_scores[0]), 0.
+                )
+
+                if len(pep_scores) > 1:
+                    manual_ambiguity = ascore.calculate_ambiguity(pep_scores[0], pep_scores[1])
+                    self.assertTrue(np.any(np.isclose(manual_ambiguity, ascore.ascores)))
+
+        test_ambiguity("velos_matches_1_mods.pkl", "velos_spectra_1_mods.pkl")
+        test_ambiguity("velos_matches_2_mods.pkl", "velos_spectra_2_mods.pkl")
+        test_ambiguity("velos_matches_3_mods.pkl", "velos_spectra_3_mods.pkl")
+


### PR DESCRIPTION
This PR is to address the second part of #4, which will allow access to internal components of the pyAscore C++ code. It will add a getter function to access the sorted PepScore containers, which can be iterated across and passed to a new ambiguity score function which will allow users to create custom analyses beyond the traditional scoring pipeline.

- [x] Add getter function for PepScore containers
- [x] Add test for PepScore getter
- [x]  Add access to ambiguity score calculator
- [x] Add test for ambiguity score calculator
- [x] Finalize documentation 

