### PR TITLE
Fix discrepancies between code and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,61 +38,41 @@ A full list of parameters is available by running with the `-h` flag.
 ```
 $ python -m pyascore -h
 
-usage: pyAscore [-h] [--match_save] [--residues RESIDUES]
-                [--mod_mass MOD_MASS] [--mz_error MZ_ERROR]
-                [--mod_correction_tol MOD_CORRECTION_TOL]
-                [--zero_based ZERO_BASED]
-                [--neutral_loss_groups NEUTRAL_LOSS_GROUPS]
-                [--neutral_loss_masses NEUTRAL_LOSS_MASSES]
-                [--hit_depth HIT_DEPTH] [--parameter_file PARAMETER_FILE]
+usage: pyAscore [-h] [--match_save] [--residues RESIDUES] [--mod_mass MOD_MASS] [--mz_error MZ_ERROR] [--mod_correction_tol MOD_CORRECTION_TOL] [--zero_based ZERO_BASED]
+                [--neutral_loss_groups NEUTRAL_LOSS_GROUPS] [--neutral_loss_masses NEUTRAL_LOSS_MASSES] [--hit_depth HIT_DEPTH] [--parameter_file PARAMETER_FILE]
                 [--ident_file_type IDENT_FILE_TYPE]
                 spec_file ident_file out_file
 
-The pyAscore module provides PTM localization analysis using a custom
-implementation of the Ascore algorithm. It employees pyteomics for efficient
-reading of spectra in mzML format and identifications in pepXML format. All
-scoring has been implemented in custom c++ code which is exposed to python via
-cython wrappers. Any PTM which be defined with a canonical amino acid and mass
-shift can be analyzed.
+The pyAscore module provides PTM localization analysis using a custom implementation of the Ascore algorithm. It employees pyteomics for efficient reading of spectra in mzML format and
+identifications in pepXML format. All scoring has been implemented in custom c++ code which is exposed to python via cython wrappers. Any PTM which be defined with a canonical amino acid and
+mass shift can be analyzed.
 
 positional arguments:
-  spec_file             MS Spectra file supplied as MzML
-  ident_file            Comet hits supplied as pepXML
-  out_file              Destination for Ascores
+  spec_file             MS Spectra file supplied as MzML.
+  ident_file            Results of database search.
+  out_file              Destination for Ascores.
 
 optional arguments:
   -h, --help            show this help message and exit
   --match_save
-  --residues RESIDUES   Residues which can be modified
-  --mod_mass MOD_MASS   Modification mass to match to identifications. This is
-                        often rounded by search engines so this argument
-                        should be considered the most accurate mass
-  --mz_error MZ_ERROR   Tolerance in mz for deciding whether a spectral peak
-                        matches to a theoretical peak.
+  --residues RESIDUES   Residues which can be modified.
+  --mod_mass MOD_MASS   Modification mass to match to identifications. This is often rounded by search engines so this argument should be considered the most accurate mass.
+  --mz_error MZ_ERROR   Tolerance in mz for deciding whether a spectral peak matches to a theoretical peak.
   --mod_correction_tol MOD_CORRECTION_TOL
-                        MZ tolerance for deciding whether a reported
-                        modification matches internal or user specified
-                        modifications. A wide tolerance can help overcome
-                        rounding. If more precission is needed, make sure to
-                        set this parameter and that your search engine
-                        provides for it.
+                        MZ tolerance for deciding whether a reported modification matches internal or user specified modifications. A wide tolerance can help overcome rounding. If more
+                        precission is needed, make sure to set this parameter and that your search engine provides for it.
   --zero_based ZERO_BASED
-                        Mod positions are by default assumed to be 1 based
+                        Mod positions are by default assumed to be 1 based.
   --neutral_loss_groups NEUTRAL_LOSS_GROUPS
-                        Comma separated clusters of amino acids which are
-                        expected to have a neutral loss. To specify that the
-                        modified versions of the amino acids should have the
-                        neutral loss, use lower case letters. e.g. 'st' vs
-                        'ST'
+                        Comma separated clusters of amino acids which are expected to have a neutral loss. To specify that the modified versions of the amino acids should have the neutral loss,
+                        use lower case letters. Example: 'st' vs 'ST'.
   --neutral_loss_masses NEUTRAL_LOSS_MASSES
-                        Mass of the neutral losses specified with
-                        neutral_loss_groups.Should have one mass per group.
+                        Comma separated neutral loss masses for each of the neutral_loss_groups. Should have one mass per group. Positive masses indicate a loss, e.g. '18.0153' for water loss,
+                        while negative masses can be used to indicate a gain.
   --hit_depth HIT_DEPTH
-                        Number of PSMS to take from each scan. Set to negative
-                        to always analyze all.
+                        Number of PSMS to take from each scan. Set to negative to always analyze all.
   --parameter_file PARAMETER_FILE
-                        A file containing parameters. e.x. param = val
+                        A file containing parameters. Example: 'residues = STY'.
   --ident_file_type IDENT_FILE_TYPE
-                        The type of file supplied for identifications. One of
-                        pepXML, percolatorTXT, or mokapotTXT. Default: pepXML
+                        The type of file supplied for identifications. One of pepXML, percolatorTXT, or mokapotTXT. Default: pepXML.
 ```

--- a/pyascore/__main__.py
+++ b/pyascore/__main__.py
@@ -41,7 +41,7 @@ def build_identification_parser(arg_ref):
 
 def build_ascore(arg_ref):
     ascore = PyAscore(bin_size=100., n_top=10,
-                      mod_group=arg_ref.residues,
+                      mod_group=arg_ref.residues.upper(),
                       mod_mass=arg_ref.mod_mass,
                       mz_error=arg_ref.mz_error)
 

--- a/pyascore/__main__.py
+++ b/pyascore/__main__.py
@@ -46,8 +46,8 @@ def build_ascore(arg_ref):
                       mz_error=arg_ref.mz_error)
 
     if arg_ref.neutral_loss_masses and arg_ref.neutral_loss_masses:
-        nl_groups = arg_ref.neutral_loss_groups.split(";")
-        nl_masses = [float(m) for m in arg_ref.neutral_loss_masses.split(";")]
+        nl_groups = arg_ref.neutral_loss_groups.split(",")
+        nl_masses = [float(m) for m in arg_ref.neutral_loss_masses.split(",")]
         [ascore.add_neutral_loss(g, m) for g,m in zip(nl_groups, nl_masses)]
  
     return ascore
@@ -90,11 +90,11 @@ def main():
     )
     parser.add_argument("--match_save", action="store_true")
     parser.add_argument("--residues", type=str, default="STY",
-                        help="Residues which can be modified")
+                        help="Residues which can be modified.")
     parser.add_argument("--mod_mass", type=float, default=79.966331,
                         help="Modification mass to match to identifications."
                              " This is often rounded by search engines so this"
-                             " argument should be considered the most accurate mass")
+                             " argument should be considered the most accurate mass.")
     parser.add_argument("--mz_error", type=float, default=0.5,
                         help="Tolerance in mz for deciding whether a spectral peak"
                              " matches to a theoretical peak.")
@@ -106,30 +106,32 @@ def main():
                              " set this parameter and that your search"
                              " engine provides for it.")
     parser.add_argument("--zero_based", type=bool, default=False,
-                        help="Mod positions are by default assumed to be 1 based")
+                        help="Mod positions are by default assumed to be 1 based.")
     parser.add_argument("--neutral_loss_groups", type=str, default="",
                         help="Comma separated clusters of amino acids"
                              " which are expected to have a neutral loss."
                              " To specify that the modified versions of the amino acids"
                              " should have the neutral loss, use lower case letters."
-                             " e.g. 'st' vs 'ST'")
+                             " Example: 'st' vs 'ST'.")
     parser.add_argument("--neutral_loss_masses", type=str, default="",
-                        help="Mass of the neutral losses specified with neutral_loss_groups."
-                             "Should have one mass per group.")
+                        help="Comma separated neutral loss masses for each of the neutral_loss_groups."
+                             " Should have one mass per group."
+                             " Positive masses indicate a loss, e.g. '18.0153' for water loss,"
+                             " while negative masses can be used to indicate a gain.")
     parser.add_argument("--hit_depth", type=int, default=1,
                         help="Number of PSMS to take from each scan."
                            " Set to negative to always analyze all.")
     parser.add_argument("--parameter_file", type=str, default="",
-                        help="A file containing parameters. e.x. param = val")
+                        help="A file containing parameters. Example: 'residues = STY'.")
     parser.add_argument("--ident_file_type", type=str, default="pepXML",
                         help="The type of file supplied for identifications."
-                             " One of pepXML, percolatorTXT. Default: pepXML")
+                             " One of pepXML, percolatorTXT, or mokapotTXT. Default: pepXML.")
     parser.add_argument("spec_file", type=str,
-                        help="MS Spectra file supplied as MzML")
+                        help="MS Spectra file supplied as MzML.")
     parser.add_argument("ident_file", type=str,
-                        help="Comet hits supplied as pepXML")
+                        help="Results of database search.")
     parser.add_argument("out_file", type=str,
-                        help="Destination for Ascores")
+                        help="Destination for Ascores.")
     args = parser.parse_args()
 
     if args.parameter_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ scipy
 pandas
 Cython
 lxml
+tqdm
 pyteomics


### PR DESCRIPTION
This PR is to address issues #9 and #12, which are about differences in the documentation vs the code.

The first fixed issue is just to add `tqdm` as a requirement for the package, as the main code will not run without it.

The second issues are annoying discrepancies between the documentation and what happens in the main script. I fixed the delineation of neutral loss groups, and forced upper case input for the main modified residues. Lower case is still allowed for specifying neutral loss groups.