### PR TITLE
Allow higher charge states in score calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ optional arguments:
                         indicate a gain.
   --fragment_types FRAGMENT_TYPES
                         Fragment ion types to score. Supported: bcyz.
+  --max_fragment_charge MAX_FRAGMENT_CHARGE
+                        Max fragment charge to use for calculating theoretical
+                        peaks. Internally, the max fragment charge will not be
+                        allowed to be greater than the PSM charge - 1.
+                        However, if a more stringent limit needs to be set,
+                        this argument can be used.
+
   --hit_depth HIT_DEPTH
                         Number of PSMS to take from each scan. Set to negative
                         to always analyze all.

--- a/pyascore/__main__.py
+++ b/pyascore/__main__.py
@@ -52,6 +52,10 @@ def validate_args(arg_ref):
             raise ValueError("The fragment type inputed, {}, is not allowed."
                              " Must be one of: {}".format(frag, allowed_fragments))
 
+    # Check max fragment charge
+    if arg_ref.max_fragment_charge < 1:
+        raise ValueError("The max fragment charge must be greater than or equal to 1")
+
 
 def build_ascore(arg_ref):
     ascore = PyAscore(bin_size=100., n_top=10,
@@ -122,7 +126,9 @@ def main():
                 ascore.score(
                     spectra["mz_values"], 
                     spectra["intensity_values"], 
-                    match["peptide"], n_variable, 1,
+                    match["peptide"], n_variable,
+                    min(args.max_fragment_charge,
+                        match["charge_state"] - 1),
                     const_mod_pos, const_mod_masses
                 )
                 alt_sites = [",".join([str(site) for site in site_list]) 

--- a/pyascore/__main__.py
+++ b/pyascore/__main__.py
@@ -120,6 +120,16 @@ def main():
             const_mod_pos, const_mod_masses, n_variable = process_mods(
                 args, match["mod_positions"], match["mod_masses"]
             )
+
+            # Try and figure out PSM charge
+            if match["charge_state"] is not None and match["charge_state"] != 0:
+                psm_charge = match["charge_state"]
+            elif spectra["precursor_charge"] is not None and spectra["precursor_charge"] != 0:
+                psm_charge = spectra["precursor_charge"]
+            else:
+                psm_charge = 2
+            psm_charge = max(psm_charge, 2)
+
             if n_variable > 0:
                 if args.match_save:
                     save_match(spectra, match)
@@ -128,7 +138,7 @@ def main():
                     spectra["intensity_values"], 
                     match["peptide"], n_variable,
                     min(args.max_fragment_charge,
-                        match["charge_state"] - 1),
+                        psm_charge - 1),
                     const_mod_pos, const_mod_masses
                 )
                 alt_sites = [",".join([str(site) for site in site_list]) 

--- a/pyascore/__main__.py
+++ b/pyascore/__main__.py
@@ -122,7 +122,7 @@ def main():
                 ascore.score(
                     spectra["mz_values"], 
                     spectra["intensity_values"], 
-                    match["peptide"], n_variable,
+                    match["peptide"], n_variable, 1,
                     const_mod_pos, const_mod_masses
                 )
                 alt_sites = [",".join([str(site) for site in site_list]) 

--- a/pyascore/config.py
+++ b/pyascore/config.py
@@ -61,6 +61,11 @@ def build_parser():
                              " while negative masses can be used to indicate a gain.")
     parser.add_argument("--fragment_types", type=str, default="by",
                         help="Fragment ion types to score. Supported: bcyz.")
+    parser.add_argument("--max_fragment_charge", type=int, default=5,
+                        help="Max fragment charge to use for calculating theoretical peaks."
+                             " Internally, the max fragment charge will not be allowed to be"
+                             " greater than the PSM charge - 1. However, if a more stringent"
+                             " limit needs to be set, this argument can be used.")
     parser.add_argument("--hit_depth", type=int, default=1,
                         help="Number of PSMS to take from each scan."
                            " Set to negative to always analyze all.")

--- a/pyascore/ptm_scoring/Ascore.pyx
+++ b/pyascore/ptm_scoring/Ascore.pyx
@@ -83,6 +83,7 @@ cdef class PyAscore:
     def score(self, np.ndarray[double, ndim=1, mode="c"] mz_arr not None, 
                     np.ndarray[double, ndim=1, mode="c"] int_arr not None,
                     str peptide, size_t n_of_mod,
+                    size_t max_fragment_charge=1,
                     np.ndarray[unsigned int, ndim=1, mode="c"] aux_mod_pos = None,
                     np.ndarray[float, ndim=1, mode="c"] aux_mod_mass = None):
         """Consume spectra and associated peptide information and score PTM localization
@@ -97,6 +98,8 @@ cdef class PyAscore:
             The peptide string without any modifications or n-terminal markings.
         n_of_mod : int > 0
             Number of unlocalized modifications on the sequence.
+        max_fragment_charge : int > 0
+            Maximum fragment charge to be used for score calculations.
         aux_mod_pos : ndarray of uint32
             Positions of fixed modifications. Most modification positions should start at 1 with 0 being
             reserved for n-terminal modifications, as seems to be the field prefered encoding.
@@ -109,10 +112,11 @@ cdef class PyAscore:
         # Build modified peptide with or without constant mods
         if aux_mod_pos is not None and aux_mod_mass is not None:
             self.modified_peptide_ptr[0].consumePeptide(peptide.encode("utf8"), n_of_mod,
+                                                        max_fragment_charge,
                                                         &aux_mod_pos[0], &aux_mod_mass[0],
                                                         aux_mod_pos.size)
         else:
-            self.modified_peptide_ptr[0].consumePeptide(peptide.encode("utf8"), n_of_mod)
+            self.modified_peptide_ptr[0].consumePeptide(peptide.encode("utf8"), n_of_mod, max_fragment_charge)
         
         # Allow modified peptide to consume peaks from binned spectra
         while (self.binned_spectra_ptr[0].getBin() < self.binned_spectra_ptr[0].getNBins()):

--- a/pyascore/ptm_scoring/ModifiedPeptide.pxd
+++ b/pyascore/ptm_scoring/ModifiedPeptide.pxd
@@ -10,8 +10,8 @@ cdef extern from "cpp/ModifiedPeptide.cpp" namespace "ptmscoring":
     cdef cppclass ModifiedPeptide:
         ModifiedPeptide(string, float, float, string)
         void addNeutralLoss(string, float)
-        void consumePeptide(string, size_t)
-        void consumePeptide(string, size_t, 
+        void consumePeptide(string, size_t, size_t)
+        void consumePeptide(string, size_t, size_t,
                             const unsigned int *, 
                             const float *,
                             size_t)

--- a/pyascore/ptm_scoring/ModifiedPeptide.pyx
+++ b/pyascore/ptm_scoring/ModifiedPeptide.pyx
@@ -110,7 +110,7 @@ cdef class PyModifiedPeptide:
 
     def get_site_determining_ions(self, np.ndarray[unsigned int, ndim=1, mode="c"] sig_1,
                                         np.ndarray[unsigned int, ndim=1, mode="c"] sig_2,
-                                        str fragment_type, size_t charge_state):
+                                        str fragment_type, size_t max_charge):
         """Determine the non-overlapping theoretical fragments of two peptides.
 
         Parameters
@@ -121,8 +121,8 @@ cdef class PyModifiedPeptide:
             Encodes the modification state that each modifiable amino acid should have in the second peptide.
         fragment_type : char
             The type of fragment graph to create, e.g. 'b'.
-        charge_state : integer > 0
-            The charge state of all fragments.
+        max_charge : integer > 0
+            Site determining ions are produced for all charge states from 1 to max_charge inclusive.
 
         Returns
         -------
@@ -139,7 +139,7 @@ cdef class PyModifiedPeptide:
             sig_vec_2.push_back(<size_t> sig_2[ind])
 
         cdef vector[vector[float]] ions = self.modified_peptide_ptr[0].getSiteDeterminingIons(
-            sig_vec_1, sig_vec_2, fragment_type.encode("utf8")[0], charge_state
+            sig_vec_1, sig_vec_2, fragment_type.encode("utf8")[0], max_charge
         )
 
         ion_arrays = (np.zeros(ions[0].size(), dtype=np.float32),

--- a/pyascore/ptm_scoring/ModifiedPeptide.pyx
+++ b/pyascore/ptm_scoring/ModifiedPeptide.pyx
@@ -47,7 +47,8 @@ cdef class PyModifiedPeptide:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    def consume_peptide(self, str peptide, size_t n_of_mod, 
+    def consume_peptide(self, str peptide, size_t n_of_mod,
+                        size_t max_fragment_charge=1,
                         np.ndarray[unsigned int, ndim=1, mode="c"] aux_mod_pos = None, 
                         np.ndarray[float, ndim=1, mode="c"] aux_mod_mass = None):
         """Consumes a single peptide sequence and creates it's internal representation
@@ -58,6 +59,8 @@ cdef class PyModifiedPeptide:
             The peptide string without any modifications or n-terminal markings
         n_of_mod : int > 0
             Number of unlocalized modifications on the sequence
+        max_fragment_charge : int > 0
+            Fragments will be considered from charge 1 to max_fragment_charge
         aux_mod_pos : ndarray of uint32
             Positions of fixed modifications. Most modification positions should start at 1 with 0 being
             reserved for n-terminal modifications, as seems to be the field prefered encoding.
@@ -65,11 +68,14 @@ cdef class PyModifiedPeptide:
             Masses of individual fixed postion modifications.
         """
         if aux_mod_pos is not None and aux_mod_mass is not None:
-            self.modified_peptide_ptr[0].consumePeptide(peptide.encode("utf8"), n_of_mod,
-                                                        &aux_mod_pos[0], &aux_mod_mass[0], 
+            self.modified_peptide_ptr[0].consumePeptide(peptide.encode("utf8"),
+                                                        n_of_mod,
+                                                        max_fragment_charge,
+                                                        &aux_mod_pos[0], 
+                                                        &aux_mod_mass[0], 
                                                         aux_mod_pos.size)
         else:
-            self.modified_peptide_ptr[0].consumePeptide(peptide.encode("utf8"), n_of_mod)
+            self.modified_peptide_ptr[0].consumePeptide(peptide.encode("utf8"), n_of_mod, max_fragment_charge)
 
     def get_peptide(self, np.ndarray[unsigned int, ndim=1, mode="c"] signature = np.ndarray(0, dtype=np.uint32)):
         """Prints the modified sequence (residues plus mod mass) of the consumed peptide

--- a/pyascore/ptm_scoring/cpp/Ascore.cpp
+++ b/pyascore/ptm_scoring/cpp/Ascore.cpp
@@ -56,60 +56,62 @@ namespace ptmscoring {
     void Ascore::accumulateCounts () {
         std::unordered_map<long, ScoreContainer> score_cache;
         for (char fragment_type : modified_peptide_ptr->getFragmentTypes()){
-            // Initialize count stack with a zero count vector
-            std::unordered_map<size_t, std::vector<size_t>> count_cache;
-            std::unordered_map<size_t, size_t> nfrag_cache;
-            count_cache[1] = std::vector<size_t>(binned_spectra_ptr->getNTop());
-            nfrag_cache[1] = 0;
+	    for (size_t charge = 1; charge <= modified_peptide_ptr->getMaxFragmentCharge(); charge++) {
+                // Initialize count stack with a zero count vector
+                std::unordered_map<size_t, std::vector<size_t>> count_cache;
+                std::unordered_map<size_t, size_t> nfrag_cache;
+                count_cache[1] = std::vector<size_t>(binned_spectra_ptr->getNTop());
+                nfrag_cache[1] = 0;
 
-            // Iterate through signatures and accumulate scores
-            std::vector<size_t> cur_count;
-            size_t cur_nfrag;
-            ModifiedPeptide::FragmentGraph graph = modified_peptide_ptr->getFragmentGraph(
-                fragment_type, 1
-            );
-            for (; !graph.isSignatureEnd(); graph.incrSignature()){
+                // Iterate through signatures and accumulate scores
+                std::vector<size_t> cur_count;
+                size_t cur_nfrag;
+                ModifiedPeptide::FragmentGraph graph = modified_peptide_ptr->getFragmentGraph(
+                    fragment_type, charge
+                );
+                for (; !graph.isSignatureEnd(); graph.incrSignature()){
 
-                // Copy last signature state
-                cur_count = count_cache[graph.getFragmentSize()];
-                cur_nfrag = nfrag_cache[graph.getFragmentSize()];
+                    // Copy last signature state
+                    cur_count = count_cache[graph.getFragmentSize()];
+                    cur_nfrag = nfrag_cache[graph.getFragmentSize()];
 
-                for (; !graph.isFragmentEnd(); graph.incrFragment()){
-                    if ( graph.isPositionModified() && !graph.isLoss() ) { 
-                        count_cache[graph.getFragmentSize()] = cur_count;
-                        nfrag_cache[graph.getFragmentSize()] = cur_nfrag;
+                    for (; !graph.isFragmentEnd(); graph.incrFragment()){
+                        if ( graph.isPositionModified() && !graph.isLoss() ) { 
+                            count_cache[graph.getFragmentSize()] = cur_count;
+                            nfrag_cache[graph.getFragmentSize()] = cur_nfrag;
+                        }
+                        float fragment_mz = graph.getFragmentMZ();
+                        if ( modified_peptide_ptr->hasMatch(fragment_mz) ){
+                            std::tuple<float, size_t> matched_peak = modified_peptide_ptr->getMatch(
+                                fragment_mz
+                            );
+                            cur_count[std::get<1>(matched_peak)]++;
+                        }
+                        cur_nfrag++;
                     }
-                    float fragment_mz = graph.getFragmentMZ();
-                    if ( modified_peptide_ptr->hasMatch(fragment_mz) ){
-                        std::tuple<float, size_t> matched_peak = modified_peptide_ptr->getMatch(
-                            fragment_mz
-                        );
-                        cur_count[std::get<1>(matched_peak)]++;
-                    }
-                    cur_nfrag++;
-                }
 
-                // Write signature info
-                long index = 0;
-                for (size_t sig_pos : graph.getSignature()) {
-                    index = (index<<1) | sig_pos;
-                }
-
-                if (!score_cache.count(index)) {
-                    score_cache[index] = {};
-                    score_cache[index].signature = graph.getSignature();
-                    score_cache[index].counts = cur_count;
-                    score_cache[index].total_fragments = cur_nfrag;
-                    //score_cache[index] = { graph.getSignature(), cur_count, {} , -1, cur_nfrag};
-                } else {
-                    ScoreContainer & score_ref = score_cache[index];
-                    for (size_t ind = 0; ind < cur_count.size(); ind++) {
-                        score_ref.counts[ind] += cur_count[ind];
+                    // Write signature info
+                    long index = 0;
+                    for (size_t sig_pos : graph.getSignature()) {
+                        index = (index<<1) | sig_pos;
                     }
-                    score_ref.total_fragments += cur_nfrag;
+
+                    if (!score_cache.count(index)) {
+                        score_cache[index] = {};
+                        score_cache[index].signature = graph.getSignature();
+                        score_cache[index].counts = cur_count;
+                        score_cache[index].total_fragments = cur_nfrag;
+                        //score_cache[index] = { graph.getSignature(), cur_count, {} , -1, cur_nfrag};
+                    } else {
+                        ScoreContainer & score_ref = score_cache[index];
+                        for (size_t ind = 0; ind < cur_count.size(); ind++) {
+                            score_ref.counts[ind] += cur_count[ind];
+                        }
+                        score_ref.total_fragments += cur_nfrag;
+                    }
                 }
             }
-        }
+	}
         
         peptide_scores_.reserve(score_cache.size());
         for (auto & cached_pair : score_cache) {

--- a/pyascore/ptm_scoring/cpp/Ascore.cpp
+++ b/pyascore/ptm_scoring/cpp/Ascore.cpp
@@ -177,7 +177,8 @@ namespace ptmscoring {
         std::vector<size_t> ion_trials(2);
         for (char fragment_type : modified_peptide_ptr->getFragmentTypes()) {
             std::vector<std::vector<float>> ions = modified_peptide_ptr->getSiteDeterminingIons(
-                ref.signature, other.signature, fragment_type, 1
+                ref.signature, other.signature, fragment_type,
+		modified_peptide_ptr->getMaxFragmentCharge()
             );
 
             ion_trials[0] += ions[0].size();

--- a/pyascore/ptm_scoring/cpp/ModifiedPeptide.cpp
+++ b/pyascore/ptm_scoring/cpp/ModifiedPeptide.cpp
@@ -82,15 +82,16 @@ namespace ptmscoring {
         fragment_scores.clear();
         fragments.clear();
         for (char t : fragment_types){
-            // Only supporting charge 1 for now
-            for (FragmentGraph graph = getFragmentGraph(t, 1);
-                 !graph.isSignatureEnd();
-                 graph.incrSignature()) {
-                for(; !graph.isFragmentEnd();
-                      graph.incrFragment()) {
-                    fragments.push_back(graph.getFragmentMZ());
+            for (size_t charge=1; charge <= max_fragment_charge; charge++) {
+                for (FragmentGraph graph = getFragmentGraph(t, charge);
+                     !graph.isSignatureEnd();
+                     graph.incrSignature()) {
+                    for(; !graph.isFragmentEnd();
+                          graph.incrFragment()) {
+                        fragments.push_back(graph.getFragmentMZ());
+                    }
                 }
-            }
+	    }
         }
         std::sort(fragments.begin(), fragments.end());
     }
@@ -101,13 +102,16 @@ namespace ptmscoring {
         }
     }
 
-    void ModifiedPeptide::consumePeptide (std::string peptide, size_t n_of_mod,
+    void ModifiedPeptide::consumePeptide (std::string peptide,
+		                          size_t n_of_mod,
+					  size_t max_fragment_charge,
                                           const unsigned int * aux_mod_pos,
                                           const float * aux_mod_mass,
                                           size_t n_aux_mods) {
 
         this->peptide = peptide;
         this->n_of_mod = n_of_mod;
+	this->max_fragment_charge = max_fragment_charge;
 
         this->aux_mod_pos.resize(n_aux_mods);
         std::copy(aux_mod_pos, aux_mod_pos + n_aux_mods, this->aux_mod_pos.begin());
@@ -163,6 +167,10 @@ namespace ptmscoring {
 
     size_t ModifiedPeptide::getNumberOfMods () const {
         return n_of_mod;
+    }
+
+    size_t ModifiedPeptide::getMaxFragmentCharge () const {
+        return max_fragment_charge;
     }
 
     size_t ModifiedPeptide::getNumberModifiable () const {

--- a/pyascore/ptm_scoring/cpp/ModifiedPeptide.cpp
+++ b/pyascore/ptm_scoring/cpp/ModifiedPeptide.cpp
@@ -250,44 +250,65 @@ namespace ptmscoring {
 
     std::vector<std::vector<float>> ModifiedPeptide::getSiteDeterminingIons (const std::vector<size_t> & signature_1,
                                                                              const std::vector<size_t> & signature_2,
-                                                                             char fragment_type, size_t charge_state) const {
+                                                                             char fragment_type, size_t max_charge) const {
+	// Generate candidate fragments for each charge state up to max
+        std::vector<float> candidate_fragments_1;
+	std::vector<float> candidate_fragments_2;
+	for (size_t charge = 1; charge <= max_charge; charge++) {
+	    // Generate fragments for signature 1
+            ModifiedPeptide::FragmentGraph graph_1 = getFragmentGraph(fragment_type, charge);
+	    graph_1.setSignature(signature_1);
+            for(; !graph_1.isFragmentEnd();
+                  graph_1.incrFragment()) {
+              candidate_fragments_1.push_back( graph_1.getFragmentMZ() );
+	    }
 
-        std::vector<std::tuple<float, size_t>> fragments;
-
-        // Gather fragments from the first signature
-        ModifiedPeptide::FragmentGraph graph_1 = getFragmentGraph(fragment_type, charge_state);
-        graph_1.setSignature(signature_1);
-        for(; !graph_1.isFragmentEnd();
-               graph_1.incrFragment()) {
-            fragments.push_back( {graph_1.getFragmentMZ(), 0} );
+	    // Generate fragments for signature 2
+	    ModifiedPeptide::FragmentGraph graph_2 = getFragmentGraph(fragment_type, charge);
+            graph_2.setSignature(signature_2);
+            for(; !graph_2.isFragmentEnd();
+                  graph_2.incrFragment()) {
+              candidate_fragments_2.push_back( graph_2.getFragmentMZ() );
+            }
         }
 
-        // Gather fragments from the second signature
-        ModifiedPeptide::FragmentGraph graph_2 = getFragmentGraph(fragment_type, charge_state);
-        graph_2.setSignature(signature_2);
-        for(; !graph_2.isFragmentEnd();
-               graph_2.incrFragment()) {
-            fragments.push_back( {graph_2.getFragmentMZ(), 1} );
-        }
+        // Sort fragments
+	std::sort(candidate_fragments_1.begin(), candidate_fragments_1.end());
+        std::sort(candidate_fragments_2.begin(), candidate_fragments_2.end());
 
-        // Only store peaks that are different
-        std::sort(fragments.begin(), fragments.end());
-        std::vector<std::vector<float>> ion_lists(2);
-        for (size_t frag_ind = 0; frag_ind < fragments.size(); frag_ind++) {
-            bool keep = true;
-            if ( frag_ind > 0 ) {
-                keep = keep && std::abs(std::get<0>(fragments[frag_ind]) - std::get<0>(fragments[frag_ind - 1])) > mz_error;
-            }
-            if ( frag_ind + 1 < fragments.size() ) {
-                keep = keep && std::abs(std::get<0>(fragments[frag_ind]) - std::get<0>(fragments[frag_ind + 1])) > mz_error;
-            }
-            if ( keep ) {
-                ion_lists[ std::get<1>(fragments[frag_ind]) ].push_back( std::get<0>(fragments[frag_ind]) );
-            }
+        // Determine non-overlapping fragments
+	std::vector<std::vector<float>> ion_lists(2);
+	std::vector<float>::iterator fragment_iter_1 = candidate_fragments_1.begin();
+	std::vector<float>::iterator fragment_iter_2 = candidate_fragments_2.begin();
+	while (fragment_iter_1 < candidate_fragments_1.end() ||
+	       fragment_iter_2 < candidate_fragments_2.end()) {
+	    // 1st and 2nd: 
+	    //   Check if one list is just finished. Just grab the rest of the other list.
+	    // 3rd:
+	    //   Check if fragments are equal given mz_error. These we will discard.
+	    // 4th and 5th:
+	    //   Check which list to take a fragment from. These are site determining peaks. 
+            if (fragment_iter_2 == candidate_fragments_2.end()) {
+                ion_lists[0].push_back(*fragment_iter_1);
+                fragment_iter_1++;
+            } else if (fragment_iter_1 == candidate_fragments_1.end()) {
+                ion_lists[1].push_back(*fragment_iter_2);
+                fragment_iter_2++;
+            } else if (std::abs(*fragment_iter_1 - *fragment_iter_2) < mz_error) {
+                fragment_iter_1++;
+                fragment_iter_2++;
+	    } else if (*fragment_iter_1 < *fragment_iter_2) { 
+	        ion_lists[0].push_back(*fragment_iter_1);
+		fragment_iter_1++;
+	    } else {
+	        ion_lists[1].push_back(*fragment_iter_2);
+		fragment_iter_2++;
+	    }
 
-        }
+	}
 
         return ion_lists;
+
     }
 
     ////////////////////////////////////////

--- a/pyascore/ptm_scoring/cpp/ModifiedPeptide.h
+++ b/pyascore/ptm_scoring/cpp/ModifiedPeptide.h
@@ -20,6 +20,7 @@ namespace ptmscoring {
 
         std::string peptide;
         size_t n_of_mod;
+	size_t max_fragment_charge;
         std::vector<unsigned int> aux_mod_pos;
         std::vector<float> aux_mod_mass;
 
@@ -38,6 +39,7 @@ namespace ptmscoring {
             void addNeutralLoss(std::string, float);
 
             void consumePeptide(std::string, size_t, 
+			        size_t = 1,
                                 const unsigned int * = NULL, 
                                 const float * = NULL, 
                                 size_t = 0);
@@ -50,6 +52,7 @@ namespace ptmscoring {
             float getMZError() const;
             std::string getFragmentTypes() const;
             size_t getNumberOfMods() const;
+	    size_t getMaxFragmentCharge() const;
             size_t getNumberModifiable() const;
             size_t getPosOfNthModifiable(size_t) const;
             std::string getBasePeptide() const;

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path, environ
 import numpy as np
 
 NAME = "pyascore"
-VERSION = 0.4
+VERSION = 0.5
 DESCR = "A python module for fast post translational modification localization."
 REQUIRES = ['cython']
 

--- a/test/test_ascore.py
+++ b/test/test_ascore.py
@@ -26,7 +26,8 @@ class TestPyAscore(unittest.TestCase):
                 ascore.score(spectra["mz_values"], 
                              spectra["intensity_values"], 
                              match["peptide"], 
-                             len(match["mod_positions"]))
+                             len(match["mod_positions"]),
+                             match["charge_state"] - 1)
                 running_time += time.time()
                 n += 1
 
@@ -44,7 +45,8 @@ class TestPyAscore(unittest.TestCase):
                 ascore.score(spectra["mz_values"],
                              spectra["intensity_values"],
                              match["peptide"],
-                             len(match["mod_positions"]))
+                             len(match["mod_positions"]),
+                             match["charge_state"] - 1)
                 running_time += time.time()
                 n += 1
 

--- a/test/test_modified_peptide_container.py
+++ b/test/test_modified_peptide_container.py
@@ -22,7 +22,7 @@ class TestPyModifiedPeptide(unittest.TestCase):
         pep.consume_peptide("PASSEFK", 2)
         test(pep)
 
-        pep.consume_peptide("ASK", 1, np.array([0]).astype(np.uint32), np.array([20.]).astype(np.float32))
+        pep.consume_peptide("ASK", 1, 1, np.array([0]).astype(np.uint32), np.array([20.]).astype(np.float32))
         test(pep)
 
     def test_signature_incr(self):
@@ -225,7 +225,7 @@ class TestPyModifiedPeptide(unittest.TestCase):
                 graph.incr_fragment()
 
         # Test modified peptide
-        pep.consume_peptide("ASMTK", 1, np.array([0, 3]).astype(np.uint32), np.array([42.010565, 15.994915]).astype(np.float32))
+        pep.consume_peptide("ASMTK", 1, 1, np.array([0, 3]).astype(np.uint32), np.array([42.010565, 15.994915]).astype(np.float32))
         max_charge = 3
         for c in range(max_charge + 1):
             # Test b fragments
@@ -348,7 +348,7 @@ class TestPyModifiedPeptide(unittest.TestCase):
             self.assertTrue(np.all(np.isclose(c, m, rtol=1e-05, atol=0)))
 
         # Site determining peaks with a single straddling constant modification
-        pep.consume_peptide("ASMSK", 1,
+        pep.consume_peptide("ASMSK", 1, 1,
                             np.array([3], dtype=np.uint32),
                             np.array([15.9949146202], dtype=np.float32))
         calc_mz = pep.get_site_determining_ions(np.array([1, 0], dtype=np.uint32),
@@ -407,7 +407,7 @@ class TestPyModifiedPeptide(unittest.TestCase):
             self.assertTrue(np.all(np.isclose(c, m, rtol=1e-05, atol=0)))
 
         # Site determining peaks with two interfering mods
-        pep.consume_peptide("PASSSMSSEFK", 2,
+        pep.consume_peptide("PASSSMSSEFK", 2, 1,
                             np.array([6], dtype=np.uint32),
                             np.array([15.9949146202], dtype=np.float32))
         calc_mz = pep.get_site_determining_ions(np.array([1, 0, 1, 0, 0], dtype=np.uint32),
@@ -429,7 +429,7 @@ class TestPyModifiedPeptide(unittest.TestCase):
     def test_site_determining_high_charge(self):
         pep = PyModifiedPeptide("STY", 79.966331)
 
-        pep.consume_peptide("ASMHSK", 1)
+        pep.consume_peptide("ASMHSK", 1, 2)
         calc_mz = pep.get_site_determining_ions(np.array([1, 0], dtype=np.uint32),
                                                 np.array([0, 1], dtype=np.uint32),
                                                 "b", 2)
@@ -449,7 +449,7 @@ class TestPyModifiedPeptide(unittest.TestCase):
     def test_peptide_print(self):
         pep = PyModifiedPeptide("STY", 79.966331)
 
-        pep.consume_peptide("ASMTK", 1, np.array([0, 3]).astype(np.uint32), np.array([42.010565, 15.994915]).astype(np.float32))
+        pep.consume_peptide("ASMTK", 1, 1, np.array([0, 3]).astype(np.uint32), np.array([42.010565, 15.994915]).astype(np.float32))
         self.assertEqual(pep.get_peptide(), "n[42]AS[80]M[16]TK")
         self.assertEqual(pep.get_peptide(np.array([0, 1], dtype=np.uint32)), "n[42]ASM[16]T[80]K")
 

--- a/test/test_modified_peptide_container.py
+++ b/test/test_modified_peptide_container.py
@@ -426,6 +426,26 @@ class TestPyModifiedPeptide(unittest.TestCase):
         for c, m in zip(calc_mz, true_mz):
             self.assertTrue(np.all(np.isclose(c, m, rtol=1e-05, atol=0)))
 
+    def test_site_determining_high_charge(self):
+        pep = PyModifiedPeptide("STY", 79.966331)
+
+        pep.consume_peptide("ASMHSK", 1)
+        calc_mz = pep.get_site_determining_ions(np.array([1, 0], dtype=np.uint32),
+                                                np.array([0, 1], dtype=np.uint32),
+                                                "b", 2)
+        true_mz = (np.array([120.02556, 185.545805, 239.0427475, 254.07526, 370.083786, 507.142696]),
+                   np.array([80.042395, 145.56264, 159.076965, 214.092095, 290.117455, 427.176365]))
+        for c, m in zip(calc_mz, true_mz):
+            self.assertTrue(np.all(np.isclose(c, m, rtol=1e-05, atol=0)))
+
+        calc_mz = pep.get_site_determining_ions(np.array([1, 0], dtype=np.uint32),
+                                                np.array([0, 1], dtype=np.uint32),
+                                                "y", 2)
+        true_mz = (np.array([117.576602, 186.106057, 234.14537, 251.626302, 371.20428, 502.24477]),
+                   np.array([157.559767, 226.089222, 291.609468, 314.111710, 451.17062, 582.211111]))
+        for c, m in zip(calc_mz, true_mz):
+            self.assertTrue(np.all(np.isclose(c, m, rtol=1e-05, atol=0)))
+
     def test_peptide_print(self):
         pep = PyModifiedPeptide("STY", 79.966331)
 


### PR DESCRIPTION
Fragment ions in both the PepScore and Ascore steps have been limited to charge 1. This works against charge 3 and up peptides in CID and HCD fragmentation spectra since there are fragment ions which are never used. This PR will attempt to address this problem, by allowing the user to specify the max fragment charge state that they want to use.