### PR TITLE
Add z1 fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ optional arguments:
                         indicate a gain.
   --fragment_types FRAGMENT_TYPES
                         Fragment ion types to score. Supported: bcyzZ. The
-                        special character Z indicates a z+1 fragment.
+                        special character Z indicates a z+H fragment.
   --max_fragment_charge MAX_FRAGMENT_CHARGE
                         Max fragment charge to use for calculating theoretical
                         peaks. Internally, the max fragment charge will not be

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ optional arguments:
                         water loss, while negative masses can be used to
                         indicate a gain.
   --fragment_types FRAGMENT_TYPES
-                        Fragment ion types to score. Supported: bcyz.
+                        Fragment ion types to score. Supported: bcyzZ. The
+                        special character Z indicates a z+1 fragment.
   --max_fragment_charge MAX_FRAGMENT_CHARGE
                         Max fragment charge to use for calculating theoretical
                         peaks. Internally, the max fragment charge will not be

--- a/pyascore/__main__.py
+++ b/pyascore/__main__.py
@@ -46,7 +46,7 @@ def validate_args(arg_ref):
                              " Must be one of: {}".format(aa, allowed_residues))
 
     # Check fragment types
-    allowed_fragments = "cbyz"
+    allowed_fragments = "cbyzZ"
     for frag in arg_ref.fragment_types:
         if frag not in allowed_fragments:
             raise ValueError("The fragment type inputed, {}, is not allowed."

--- a/pyascore/config.py
+++ b/pyascore/config.py
@@ -60,7 +60,8 @@ def build_parser():
                              " Positive masses indicate a loss, e.g. '18.0153' for water loss,"
                              " while negative masses can be used to indicate a gain.")
     parser.add_argument("--fragment_types", type=str, default="by",
-                        help="Fragment ion types to score. Supported: bcyz.")
+                        help="Fragment ion types to score. Supported: bcyzZ."
+                             " The special character Z indicates a z+1 fragment.")
     parser.add_argument("--max_fragment_charge", type=int, default=5,
                         help="Max fragment charge to use for calculating theoretical peaks."
                              " Internally, the max fragment charge will not be allowed to be"

--- a/pyascore/config.py
+++ b/pyascore/config.py
@@ -61,7 +61,7 @@ def build_parser():
                              " while negative masses can be used to indicate a gain.")
     parser.add_argument("--fragment_types", type=str, default="by",
                         help="Fragment ion types to score. Supported: bcyzZ."
-                             " The special character Z indicates a z+1 fragment.")
+                             " The special character Z indicates a z+H fragment.")
     parser.add_argument("--max_fragment_charge", type=int, default=5,
                         help="Max fragment charge to use for calculating theoretical peaks."
                              " Internally, the max fragment charge will not be allowed to be"

--- a/pyascore/ptm_scoring/cpp/ModifiedPeptide.cpp
+++ b/pyascore/ptm_scoring/cpp/ModifiedPeptide.cpp
@@ -339,7 +339,7 @@ namespace ptmscoring {
     void ModifiedPeptide::FragmentGraph::resetResidueInd () {
         if ( fragment_type == 'b' || fragment_type == 'c' ) {
             residue_ind = 0;
-        } else if ( fragment_type == 'y'  || fragment_type == 'z' ) {
+        } else if ( fragment_type == 'y'  || fragment_type == 'z' || fragment_type == 'Z' ) {
             residue_ind = modified_peptide->residues.size() - 1;
         } else { throw 30; }
     }
@@ -347,7 +347,7 @@ namespace ptmscoring {
     void ModifiedPeptide::FragmentGraph::setResidueInd (size_t new_ind) {
         if ( fragment_type == 'b' || fragment_type == 'c' ) {
             residue_ind = std::min(residue_ind, new_ind);
-        } else if ( fragment_type == 'y' || fragment_type == 'z' ) {
+        } else if ( fragment_type == 'y' || fragment_type == 'z' || fragment_type == 'Z' ) {
             residue_ind = residue_ind == SIZE_MAX ? new_ind : std::max(residue_ind, new_ind);
         } else { throw 30; }
     }
@@ -355,7 +355,7 @@ namespace ptmscoring {
     void ModifiedPeptide::FragmentGraph::incrResidueInd () {
         if ( fragment_type == 'b' || fragment_type == 'c' ) {
             residue_ind++;
-        } else if ( fragment_type == 'y' || fragment_type == 'z' ) {
+        } else if ( fragment_type == 'y' || fragment_type == 'z' || fragment_type == 'Z' ) {
             residue_ind--;
         } else { throw 30; }
     }
@@ -363,7 +363,7 @@ namespace ptmscoring {
     bool ModifiedPeptide::FragmentGraph::isResidueEnd () {
         if ( fragment_type == 'b' || fragment_type == 'c' ) {
             return residue_ind == modified_peptide->residues.size();
-        } else if ( fragment_type == 'y' || fragment_type == 'z' ) {
+        } else if ( fragment_type == 'y' || fragment_type == 'z' || fragment_type == 'Z' ) {
             return residue_ind == SIZE_MAX;
         } else { throw 30; }
     }
@@ -371,7 +371,7 @@ namespace ptmscoring {
     size_t ModifiedPeptide::FragmentGraph::getResidueDistance () {
         if ( fragment_type == 'b' || fragment_type == 'c' ) {
             return residue_ind;
-        } else if ( fragment_type == 'y' || fragment_type == 'z' ) {
+        } else if ( fragment_type == 'y' || fragment_type == 'z' || fragment_type == 'Z' ) {
             return modified_peptide->residues.size() - residue_ind - 1;
         } else { throw 30; }
     }
@@ -512,7 +512,7 @@ namespace ptmscoring {
         bool last_fragment;
         if ( fragment_type == 'b' || fragment_type == 'c' ) {
             last_fragment = residue_ind == modified_peptide->residues.size() - 1;
-        } else if ( fragment_type == 'y' || fragment_type == 'z' ) {
+        } else if ( fragment_type == 'y' || fragment_type == 'z' || fragment_type == 'Z') {
             last_fragment = residue_ind == 0;
         } else { throw 30; }
         return last_fragment && !neutral_loss_iter.hasNext();
@@ -525,7 +525,7 @@ namespace ptmscoring {
     void ModifiedPeptide::FragmentGraph::setSignature (std::vector<size_t> new_signature) {
         if (new_signature.size() != modifiable.size()) {throw 50;}
         
-        if (fragment_type == 'y' || fragment_type == 'z') {
+        if (fragment_type == 'y' || fragment_type == 'z' || fragment_type == 'Z') {
             std::reverse(new_signature.begin(), new_signature.end());
         }
 
@@ -555,7 +555,7 @@ namespace ptmscoring {
         }
 
         // For efficiency's sake, y fragment signatures are always backwards
-        if (fragment_type == 'y' || fragment_type == 'z') {
+        if (fragment_type == 'y' || fragment_type == 'z' || fragment_type == 'Z') {
             std::reverse(signature_vector.begin(), signature_vector.end());
         }
 
@@ -570,6 +570,9 @@ namespace ptmscoring {
         } else if (fragment_type == 'z') {
             fragment_mz += 18.010565; // Gain of H2O
             fragment_mz -= 17.026549; // Loss of NH3
+        } else if (fragment_type == 'Z') {
+            fragment_mz += 18.010565; // Gain of H2O
+            fragment_mz -= 16.018724; // Loss of NH2
         } else if (fragment_type == 'c') {
             fragment_mz += 17.026549; // Gain of NH3
         }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path, environ
 import numpy as np
 
 NAME = "pyascore"
-VERSION = 0.5
+VERSION = 0.6
 DESCR = "A python module for fast post translational modification localization."
 REQUIRES = ['cython']
 

--- a/test/test_modified_peptide_container.py
+++ b/test/test_modified_peptide_container.py
@@ -173,6 +173,19 @@ class TestPyModifiedPeptide(unittest.TestCase):
             z_graph.incr_signature()
             test(z_graph, c, np.array([129.07897, 230.12665, 361.16714, 528.16550]))
 
+            # Test z fragments
+            z_graph = pep.get_fragment_graph("Z", c)
+            # First signature all the way through
+            test(z_graph, c, np.array([130.086795, 311.100805, 442.141295, 529.173325]))
+            self.assertTrue(y_graph.is_fragment_end())
+            # Second signature, picking up from common node
+            z_graph.incr_signature()
+            test(z_graph, c, np.array([231.134475, 362.174965, 529.173325]))
+            # Second signature, from beginning
+            z_graph.reset_iterator()
+            z_graph.incr_signature()
+            test(z_graph, c, np.array([130.086795, 231.134475, 362.174965, 529.173325]))
+
     def test_fragment_incr_terminal(self):
         pep = PyModifiedPeptide("nKc", 42.010565)
 
@@ -279,6 +292,19 @@ class TestPyModifiedPeptide(unittest.TestCase):
             z_graph.reset_iterator()
             z_graph.incr_signature()
             test(z_graph, c, np.array([129.07897, 230.12665, 377.16206, 544.16042]))
+
+            # Test Z fragments
+            z_graph = pep.get_fragment_graph("Z", c)
+            # First signature all the way through
+            test(z_graph, c, np.array([130.086795, 311.100805, 458.136215, 545.168245]))
+            self.assertTrue(z_graph.is_fragment_end())
+            # Second signature, picking up from common node
+            z_graph.incr_signature()
+            test(z_graph, c, np.array([231.134475, 378.169885, 545.168245]))
+            # Second signature, from beginning
+            z_graph.reset_iterator()
+            z_graph.incr_signature()
+            test(z_graph, c, np.array([130.086795, 231.134475, 378.169885, 545.168245]))
 
     def test_fragment_incr_nl(self):
         pep = PyModifiedPeptide("STY", 79.966331)


### PR DESCRIPTION
In learning about z fragments, I saw that pyAscore was not supporting a prominent fragment that is supported in Comet and Mascot. This is namely the z+H fragment, which appears to arise from the z radical stealing a hydrogen. This does not add an extra charge, but just adds a hydrogen mass. 