### PR TITLE
Allow passing constant mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ usage: pyAscore [-h] [--match_save] [--residues RESIDUES]
                 [--zero_based ZERO_BASED]
                 [--neutral_loss_groups NEUTRAL_LOSS_GROUPS]
                 [--neutral_loss_masses NEUTRAL_LOSS_MASSES]
-                [--fragment_types FRAGMENT_TYPES] [--hit_depth HIT_DEPTH]
-                [--parameter_file PARAMETER_FILE]
+                [--static_mod_groups STATIC_MOD_GROUPS]
+                [--static_mod_masses STATIC_MOD_MASSES]
+                [--fragment_types FRAGMENT_TYPES]
+                [--max_fragment_charge MAX_FRAGMENT_CHARGE]
+                [--hit_depth HIT_DEPTH] [--parameter_file PARAMETER_FILE]
                 [--spec_file_type SPEC_FILE_TYPE]
                 [--ident_file_type IDENT_FILE_TYPE]
                 spec_file ident_file out_file
@@ -97,6 +100,12 @@ optional arguments:
                         Positive masses indicate a loss, e.g. '18.0153' for
                         water loss, while negative masses can be used to
                         indicate a gain.
+  --static_mod_groups STATIC_MOD_GROUPS
+                        Comma separated clusters of amino acids which will be
+                        read in with a constant modification.
+  --static_mod_masses STATIC_MOD_MASSES
+                        Comma separated masses for each of the
+                        static_mod_groups.
   --fragment_types FRAGMENT_TYPES
                         Fragment ion types to score. Supported: bcyzZ. The
                         special character Z indicates a z+H fragment.
@@ -106,7 +115,6 @@ optional arguments:
                         allowed to be greater than the PSM charge - 1.
                         However, if a more stringent limit needs to be set,
                         this argument can be used.
-
   --hit_depth HIT_DEPTH
                         Number of PSMS to take from each scan. Set to negative
                         to always analyze all.
@@ -115,7 +123,7 @@ optional arguments:
                         STY'.
   --spec_file_type SPEC_FILE_TYPE
                         The type of file supplied for spectra. One of mzML or
-                        mzXML. Default: mzXML.
+                        mzXML. Default: mzML.
   --ident_file_type IDENT_FILE_TYPE
                         The type of file supplied for identifications. One of
                         pepXML, mzIdentML, percolatorTXT, or mokapotTXT.

--- a/pyascore/__main__.py
+++ b/pyascore/__main__.py
@@ -22,16 +22,24 @@ def parse_spectra(arg_ref):
 def parse_identifications(arg_ref):
     print("{} -- Reading identifications from: {}".format(get_time_stamp(), arg_ref.ident_file))
 
+    # Update static modifications
+    static_mods = {}
+    for aa_group, mass in zip(arg_ref.static_mod_groups.split(","),
+                              arg_ref.static_mod_masses.split(",")):
+        static_mods.update({aa : float(mass) for aa in aa_group})
+
     # Build mass corrector
     mods = COMMON_MODS.copy()
     mods.update({aa : arg_ref.mod_mass for aa in arg_ref.residues})
+    mods.update(static_mods)
     mass_corrector = MassCorrector(mod_mass_dict=mods)
-    
+
     # Parse
     id_parser = iter(
         sorted(IdentificationParser(arg_ref.ident_file,
                                     arg_ref.ident_file_type,
-                                    mass_corrector).to_list(),
+                                    mass_corrector,
+                                    static_mods=static_mods).to_list(),
                key=lambda spec: spec["scan"])
     )
     return id_parser

--- a/pyascore/config.py
+++ b/pyascore/config.py
@@ -59,6 +59,11 @@ def build_parser():
                              " Should have one mass per group."
                              " Positive masses indicate a loss, e.g. '18.0153' for water loss,"
                              " while negative masses can be used to indicate a gain.")
+    parser.add_argument("--static_mod_groups", type=str, default="C",
+                        help="Comma separated clusters of amino acids"
+                             " which will be read in with a constant modification.")
+    parser.add_argument("--static_mod_masses", type=str, default="57.021464",
+                        help="Comma separated masses for each of the static_mod_groups.")
     parser.add_argument("--fragment_types", type=str, default="by",
                         help="Fragment ion types to score. Supported: bcyzZ."
                              " The special character Z indicates a z+H fragment.")

--- a/pyascore/config.py
+++ b/pyascore/config.py
@@ -84,7 +84,7 @@ def build_parser():
                         help="The type of file supplied for identifications."
                              " One of pepXML, mzIdentML, percolatorTXT, or mokapotTXT. Default: pepXML.")
     parser.add_argument("spec_file", type=str,
-                        help="MS Spectra file supplied as MzML.")
+                        help="MS Spectra file.")
     parser.add_argument("ident_file", type=str,
                         help="Results of database search.")
     parser.add_argument("out_file", type=str,


### PR DESCRIPTION
I realized that programs like Percolator and Mokapot were not writing static mod masses. I was handling this internally but not allowing the user to define custom static mods in cases like TMT labeling. This PR fixes that problem.