### PR TITLE
Update PSM extraction from mzIdentML files

### DIFF
--- a/pyascore/parsing/id_parsers.py
+++ b/pyascore/parsing/id_parsers.py
@@ -305,7 +305,14 @@ class MzIdentMLExtractor(IDExtractor):
             Scan number for PSM
         """
         try:
-            return int(re.search("[0-9]+", self.entry["spectrumID"]).group())
+            # Specific search
+            scan_search = re.search("(?<=scan=)([0-9]+)", self.entry["spectrumID"])
+
+            # If specific search fails, do liberal first number search
+            if scan_search is None:
+                scan_search = re.search("[0-9]+", self.entry["spectrumID"])
+
+            return int(scan_search.group())
         except KeyError:
             return -1
 

--- a/pyascore/parsing/id_parsers.py
+++ b/pyascore/parsing/id_parsers.py
@@ -95,9 +95,10 @@ class MassCorrector:
             return (res,), (pos,), (mod_mass,)
 
         else:
+            pred_mod_mass = mass - STD_AA_MASS.get(res, 0.)
             warnings.warn("Unrecognized mod on {} at position {} with mass: {}"
-                          " Using uncorrected mass.".format(res, pos, mass))
-            return (res,), (pos,), (mass,)
+                          " Using uncorrected mass.".format(res, pos, pred_mod_mass))
+            return (res,), (pos,), (pred_mod_mass,)
 
     def correct_multiple(self, peptide, positions, masses):
         """Run the correction function on a list of mods for a single peptide
@@ -369,8 +370,15 @@ class MzIdentMLExtractor(IDExtractor):
             mass = np.zeros(len(mod_list), dtype=np.float32)
             for ind, mod in enumerate(mod_list):
                 pos[ind] = int(mod["location"])
-                aa = mod["residues"][0]
-                mass[ind] = STD_AA_MASS[aa] + float(mod["monoisotopicMassDelta"])
+                
+                # Sometimes the amino acid is already available, sometimes not
+                if "residues" in mod:
+                    aa = mod["residues"][0]
+                else:
+                    aa = ("n" + self._get_peptide() + "c")[pos[ind]]
+                
+                mass[ind] = STD_AA_MASS.get(aa, 0.) + float(mod["monoisotopicMassDelta"])
+
             return pos, mass
 
         except KeyError:

--- a/test/example_inputs/psms/test_psms.mzid
+++ b/test/example_inputs/psms/test_psms.mzid
@@ -314,7 +314,7 @@
             <cvParam cvRef="MS" accession="MS:1001156" name="SEQUEST:deltacn" value="0.312209994"/>
           </SpectrumIdentificationItem>
         </SpectrumIdentificationResult>
-        <SpectrumIdentificationResult id="SIR_1" spectrumID="14760-14760">
+        <SpectrumIdentificationResult id="SIR_1" spectrumID="scan=14760">
           <SpectrumIdentificationItem id="SII_2" rank="1" chargeState="3" peptide_ref="PEP_1" experimentalMassToCharge="846.306457519531" calculatedMassToCharge="846.310852050781" passThreshold="true">
             <PeptideEvidenceRef peptideEvidence_ref="PE_2"/>
             <cvParam cvRef="MS" accession="MS:1001155" name="SEQUEST:xcorr" value="4.48925829"/>
@@ -326,7 +326,7 @@
             <cvParam cvRef="MS" accession="MS:1001156" name="SEQUEST:deltacn" value="0.306879014"/>
           </SpectrumIdentificationItem>
         </SpectrumIdentificationResult>
-        <SpectrumIdentificationResult id="SIR_2" spectrumID="20462-20462">
+        <SpectrumIdentificationResult id="SIR_2" spectrumID="controllerType=0 controllerNumber=1 scan=20462">
           <SpectrumIdentificationItem id="SII_4" rank="1" chargeState="3" peptide_ref="PEP_2" experimentalMassToCharge="858.378601074219" calculatedMassToCharge="858.374389648438" passThreshold="true">
             <PeptideEvidenceRef peptideEvidence_ref="PE_4"/>
             <cvParam cvRef="MS" accession="MS:1001155" name="SEQUEST:xcorr" value="3.30343485"/>
@@ -352,7 +352,7 @@
             <cvParam cvRef="MS" accession="MS:1001156" name="SEQUEST:deltacn" value="0.752956986"/>
           </SpectrumIdentificationItem>
         </SpectrumIdentificationResult>
-        <SpectrumIdentificationResult id="SIR_4" spectrumID="18330-18330">
+        <SpectrumIdentificationResult id="SIR_4" spectrumID="scan=18330">
           <SpectrumIdentificationItem id="SII_8" rank="1" chargeState="3" peptide_ref="PEP_4" experimentalMassToCharge="871.696166992188" calculatedMassToCharge="871.695617675781" passThreshold="true">
             <PeptideEvidenceRef peptideEvidence_ref="PE_10"/>
             <PeptideEvidenceRef peptideEvidence_ref="PE_11"/>
@@ -368,7 +368,7 @@
             <cvParam cvRef="MS" accession="MS:1001156" name="SEQUEST:deltacn" value="0.0404415987"/>
           </SpectrumIdentificationItem>
         </SpectrumIdentificationResult>
-        <SpectrumIdentificationResult id="SIR_5" spectrumID="35669-35669">
+        <SpectrumIdentificationResult id="SIR_5" spectrumID="controllerType=0 controllerNumber=1 scan=35669">
           <SpectrumIdentificationItem id="SII_10" rank="1" chargeState="3" peptide_ref="PEP_5" experimentalMassToCharge="885.028625488281" calculatedMassToCharge="885.028503417969" passThreshold="true">
             <PeptideEvidenceRef peptideEvidence_ref="PE_16"/>
             <cvParam cvRef="MS" accession="MS:1001155" name="SEQUEST:xcorr" value="3.87117219"/>
@@ -400,7 +400,7 @@
             <cvParam cvRef="MS" accession="MS:1001156" name="SEQUEST:deltacn" value="0.239544004"/>
           </SpectrumIdentificationItem>
         </SpectrumIdentificationResult>
-        <SpectrumIdentificationResult id="SIR_7" spectrumID="31328-31328">
+        <SpectrumIdentificationResult id="SIR_7" spectrumID="scan=31328">
           <SpectrumIdentificationItem id="SII_14" rank="1" chargeState="3" peptide_ref="PEP_8" experimentalMassToCharge="1078.43017578125" calculatedMassToCharge="1078.42919921875" passThreshold="true">
             <PeptideEvidenceRef peptideEvidence_ref="PE_28"/>
             <PeptideEvidenceRef peptideEvidence_ref="PE_29"/>
@@ -416,7 +416,7 @@
             <cvParam cvRef="MS" accession="MS:1001156" name="SEQUEST:deltacn" value="0.615577996"/>
           </SpectrumIdentificationItem>
         </SpectrumIdentificationResult>
-        <SpectrumIdentificationResult id="SIR_8" spectrumID="21996-21996">
+        <SpectrumIdentificationResult id="SIR_8" spectrumID="controllerType=0 controllerNumber=1 scan=21996">
           <SpectrumIdentificationItem id="SII_16" rank="1" chargeState="3" peptide_ref="PEP_9" experimentalMassToCharge="1116.095703125" calculatedMassToCharge="1115.762817382813" passThreshold="true">
             <PeptideEvidenceRef peptideEvidence_ref="PE_34"/>
             <PeptideEvidenceRef peptideEvidence_ref="PE_35"/>

--- a/test/example_inputs/psms/test_psms.mzid
+++ b/test/example_inputs/psms/test_psms.mzid
@@ -132,7 +132,7 @@
     </Peptide>
     <Peptide id="PEP_1">
       <PeptideSequence>KMSDDEDDDEEEYGKEEHEK</PeptideSequence>
-      <Modification location="3" residues="S" monoisotopicMassDelta="79.97">
+      <Modification location="3" monoisotopicMassDelta="79.97">
         <cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value=""/>
       </Modification>
     </Peptide>
@@ -144,7 +144,7 @@
     </Peptide>
     <Peptide id="PEP_3">
       <PeptideSequence>GKEELAEAEIIKDSPDSPEPPNK</PeptideSequence>
-      <Modification location="17" residues="S" monoisotopicMassDelta="79.97">
+      <Modification location="17" monoisotopicMassDelta="79.97">
         <cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value=""/>
       </Modification>
     </Peptide>
@@ -156,7 +156,7 @@
     </Peptide>
     <Peptide id="PEP_5">
       <PeptideSequence>VEEESTGDPFGFDSDDESLPVSSK</PeptideSequence>
-      <Modification location="14" residues="S" monoisotopicMassDelta="79.97">
+      <Modification location="14" monoisotopicMassDelta="79.97">
         <cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value=""/>
       </Modification>
     </Peptide>
@@ -165,7 +165,7 @@
       <Modification location="4" residues="T" monoisotopicMassDelta="79.97">
         <cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value=""/>
       </Modification>
-      <Modification location="19" residues="S" monoisotopicMassDelta="79.97">
+      <Modification location="19" monoisotopicMassDelta="79.97">
         <cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value=""/>
       </Modification>
     </Peptide>
@@ -177,7 +177,7 @@
     </Peptide>
     <Peptide id="PEP_8">
       <PeptideSequence>EGHSLEMENENLVENGADSDEDDNSFLK</PeptideSequence>
-      <Modification location="7" residues="M" monoisotopicMassDelta="15.99">
+      <Modification location="7" monoisotopicMassDelta="15.99">
         <cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value=""/>
       </Modification>
       <Modification location="19" residues="S" monoisotopicMassDelta="79.97">


### PR DESCRIPTION
This PR addresses the issue raised in #29. The main problem lies in the fact that mzIdentML files encode the origin spectrum for each PSM as a string. For Comet and MS-GF+, this string includes an entry that has the form "scan=#". However, it can also include a lot of other metadata. Originally, I was assuming the only metadata was the scan number, but I realize now that was incorrect. By updating the regex in the mzIdentML parser, I was able to handle the cases where there is an explicit "scan" entry, and I just decided to take the first number when that element is not present.

While fixing this initial bug, I also found a bug where some mzIdentML files do not include the modified residue in the entry for peptide modifications. I would search for this key, and would just skip modification extraction if even one wasn't present. This PR fixes this bug so that when the modified residue is not present, I take the residue from the unmodified peptide sequence.

For both of these issues, I updated the mzIdentML in the `test/example_input` folder to include currently known edge cases. This should serve as a sufficient test.