### PR TITLE
Continue file reading fixes

### DIFF
--- a/pyascore/parsing/id_parsers.py
+++ b/pyascore/parsing/id_parsers.py
@@ -352,7 +352,7 @@ class MzIdentMLExtractor(IDExtractor):
             Peptide sequence without modifications
         """
         try:
-            return self._match["PeptideEvidenceRef"][0]["PeptideSequence"]
+            return self._match["PeptideSequence"]
         except KeyError:
             return ""
 

--- a/pyascore/parsing/spec_parsers.py
+++ b/pyascore/parsing/spec_parsers.py
@@ -103,7 +103,9 @@ class MzMLExtractor(SpectraExtractor):
             Tuple with fragment m/z array (0) and intensity array (1)
         """
         try:
-            return self.scan["m/z array"], self.scan["intensity array"]
+            mzs = self.scan["m/z array"].astype(np.float64)
+            intensities = self.scan["intensity array"].astype(np.float64)
+            return mzs, intensities
         except:
             return np.array([], dtype=np.float64), np.array([], dtype=np.float64)
 
@@ -163,7 +165,9 @@ class MzXMLExtractor(SpectraExtractor):
             Tuple with fragment m/z array (0) and intensity array (1)
         """
         try:
-            return self.scan["m/z array"], self.scan["intensity array"]
+            mzs = self.scan["m/z array"].astype(np.float64)
+            intensities = self.scan["intensity array"].astype(np.float64)
+            return mzs, intensities
         except:
             return np.array([], dtype=np.float64), np.array([], dtype=np.float64)
 


### PR DESCRIPTION
This PR addresses two issues with file reading.

The first is with mzIdentML files. Previously, there was some issue with the fact that missing links within the mzIdentML itself were causing the "PeptideEvidenceRef" attribute to lack sequence information. The simple fix here is to just get the PeptideSequence from the standard match object.

The second file reading issue was in spectra files which have mz and intensity values encoded with float precision. Pyteomics with faithfully recreate this. However, pyAscore expects double precision. So I enforce this during file reading.