### PR TITLE
Improve iterator

### DIFF
--- a/docs/source/api/modified_peptides.rst
+++ b/docs/source/api/modified_peptides.rst
@@ -1,6 +1,86 @@
 Working with modified peptides
 ------------------------------
 
+When trying to score the localization of a modification on a peptide's sequence,
+it is often necessary to enumerate all possible localizations of the modification
+and calculate a score. pyAscore has an internal class for doing this enumeration,
+and we make that interface available to users to allow convenient iteration
+over the theoretical fragments of modified peptides.
+
+Iteration over all fragments
+############################
+
+Basic iteration requires a peptide sequence (e.g. 'ASMTK'), the mass of a modification
+of interest (e.g. 79.9663), the amino acids that the modification can fall on (e.g STY),
+and the number of modifications of interest. All this can be initialized for a given
+peptide with the following lines.
+
+.. code-block:: python
+
+   pep = PyModifiedPeptide("STY", 79.9663)
+   pep.consume_peptide("ASMTK", 1)
+
+The **PyModifiedPeptide** object is where we will get our graphs which allow iteration
+over the theoretical fragments from permutations of modified amino acids. In this case,
+there are 2 permutations, AS[79.9663]MTK and ASMT[79.9663]K. If we would like to iterate
+over the b fragments of charge 1, we can do that by generating the b+ fragment graph
+and iterating using the **iter_permutations** and **iter_fragments** methods.
+
+.. code-block:: python
+
+   b_graph = pep.get_fragment_graph("b", 1)
+   for perm in b_graph.iter_permutations():
+       print(perm.get_signature())
+       for mz, label in graph.iter_fragments():
+           print(mz, "<-", label)
+
+.. code-block:: none
+
+   # Output:
+   [1, 0]
+   72.0449 <- b1+
+   239.043 <- b2+
+   370.084 <- b3+
+   471.131 <- b4+
+   [0, 1]
+   72.0449 <- b1+
+   159.077 <- b2+
+   290.117 <- b3+
+   471.131 <- b4+
+
+Notice that the full peptide mass is currently not included. This is because this "fragment"
+can't be used for localization.
+
+When recording scores, we tend to build a dictionary that uses the signature as a key.
+This allows us to track additive scores, such as the counts pyAscore uses, and iterate
+over graphs independently of each other. Note that one of the big reasons we do that
+is that iteration over b type permutations is in the opposite direction to the y type
+permutations.
+
+.. code-block:: python
+
+   print("b type iteration:")
+   b_graph = pep.get_fragment_graph("b", 1)
+   for perm in b_graph.iter_permutations():
+       print(perm.get_signature())
+
+   print("y type iteration:")
+   y_graph = pep.get_fragment_graph("y", 1)
+   for perm in y_graph.iter_permutations():
+       print(perm.get_signature())
+
+.. code-block:: none
+
+   # Output
+   b type iteration:
+   [1, 0]
+   [0, 1]
+   y type iteration:
+   [0, 1]
+   [1, 0]
+
 .. autoclass:: pyascore.PyModifiedPeptide
    :members:
 
+.. autoclass:: pyascore.PyFragmentGraph
+   :members:

--- a/pyascore/__init__.py
+++ b/pyascore/__init__.py
@@ -1,2 +1,2 @@
-from .ptm_scoring import PyBinnedSpectra, PyModifiedPeptide, PyAscore, PyLogMath, PyBinomialDist, PyPowerSetSum
+from .ptm_scoring import PyBinnedSpectra, PyModifiedPeptide, PyFragmentGraph, PyAscore, PyLogMath, PyBinomialDist, PyPowerSetSum
 from .parsing import *

--- a/pyascore/ptm_scoring/ModifiedPeptide.pxd
+++ b/pyascore/ptm_scoring/ModifiedPeptide.pxd
@@ -28,6 +28,7 @@ cdef extern from "cpp/ModifiedPeptide.cpp" namespace "ptmscoring":
             void resetIterator();
             void incrSignature();
             bint isSignatureEnd();
+            void resetFragment();
             void incrFragment();
             bint isFragmentEnd();
 

--- a/pyascore/ptm_scoring/ModifiedPeptide.pyx
+++ b/pyascore/ptm_scoring/ModifiedPeptide.pyx
@@ -97,7 +97,7 @@ cdef class PyModifiedPeptide:
 
         return self.modified_peptide_ptr[0].getPeptide(signature_vector).decode("utf8")
 
-    def get_fragment_graph(self, str fragment_type, size_t charge_state):
+    def get_fragment_graph(self, str fragment_type, size_t charge_state, str mode = "all"):
         """Builds a PyFragmentGraph object which references the current PyModifiedPeptide object
 
         Parameters
@@ -112,7 +112,7 @@ cdef class PyModifiedPeptide:
         PyFragmentGraph
             The fragment graph of specified type and charge state.
         """
-        return PyFragmentGraph(self, fragment_type.encode("utf8")[0], charge_state)
+        return PyFragmentGraph(self, fragment_type.encode("utf8")[0], charge_state, mode)
 
     def get_site_determining_ions(self, np.ndarray[unsigned int, ndim=1, mode="c"] sig_1,
                                         np.ndarray[unsigned int, ndim=1, mode="c"] sig_2,
@@ -187,9 +187,12 @@ cdef class PyFragmentGraph:
     charge_state : int
         The current charge state for fragments returned from the graph
     """
+    cdef str mode
     cdef ModifiedPeptide.FragmentGraph * fragment_graph_ptr
 
-    def __cinit__(self, PyModifiedPeptide peptide, char fragment_type, size_t charge_state):
+    def __cinit__(self, PyModifiedPeptide peptide, char fragment_type, size_t charge_state, str mode = "all"):
+        assert mode in ("all", "reduced")
+        self.mode = mode
         self.fragment_graph_ptr = new ModifiedPeptide.FragmentGraph(
             peptide.modified_peptide_ptr, fragment_type, charge_state
         )
@@ -199,7 +202,8 @@ cdef class PyFragmentGraph:
 
     @property
     def fragment_type(self):
-        return self.fragment_graph_ptr[0].getFragmentType()
+        cdef bytes frag_type = self.fragment_graph_ptr[0].getFragmentType()
+        return frag_type.decode('utf-8')
 
     @property
     def charge_state(self):
@@ -293,3 +297,33 @@ cdef class PyFragmentGraph:
         """
         return self.fragment_graph_ptr[0].getFragmentSeq().decode('utf8')
 
+    def iter_permutations(self):
+        """Iterate through remaining signatures and return fragment graph ready for iteration.
+
+        If mode == 'all', reset fragments to the first position before returning graph.
+
+        Yields
+        ------
+        PyFragmentGraph
+            reference to current graph
+        """
+        while not self.is_signature_end():
+            yield self
+  
+            self.incr_signature()
+            if self.mode == "all":
+              self.reset_fragment()
+
+    def iter_fragments(self):
+        """Iterate through remaining fragments of current signature.
+        
+        Yields
+        ------
+        (float, string)
+            pair of fragment mz and fragment label
+        """
+        while not self.is_fragment_end():
+            label = self.fragment_type + str(self.get_fragment_size())
+            result = (self.get_fragment_mz(), label)
+            self.incr_fragment()
+            yield result

--- a/pyascore/ptm_scoring/ModifiedPeptide.pyx
+++ b/pyascore/ptm_scoring/ModifiedPeptide.pyx
@@ -223,6 +223,10 @@ cdef class PyFragmentGraph:
         """
         return self.fragment_graph_ptr[0].isSignatureEnd()
 
+    def reset_fragment(self):
+        """Resets iterator to the first position of the current signature."""
+        return self.fragment_graph_ptr[0].resetFragment()
+
     def incr_fragment(self):
         """Increment to next fragment for current signature."""
         return self.fragment_graph_ptr[0].incrFragment()

--- a/pyascore/ptm_scoring/cpp/ModifiedPeptide.cpp
+++ b/pyascore/ptm_scoring/cpp/ModifiedPeptide.cpp
@@ -408,21 +408,7 @@ namespace ptmscoring {
     }
 
     void ModifiedPeptide::FragmentGraph::resetIterator () {
-        // Intialize running state trackers
-        // Makes sure enough space is available and
-        // clears away any old data.
-        size_t peptide_size = modified_peptide->peptide.size();
-        running_sum.reserve(peptide_size);
-        running_sum.clear();
-
-        running_sequence.reserve(peptide_size);
-        running_sequence.clear();
-
-        running_loss_count.reserve(peptide_size);
-        running_loss_count.clear();
-        neutral_loss_stack.clear();
-        neutral_loss_iter.reset(neutral_loss_stack, 2);
-
+	// First reset signature, then reset fragment
         modifiable.clear();
         signature.clear();
 
@@ -439,10 +425,7 @@ namespace ptmscoring {
             }
         }
 
-        // Reset to first step
-        resetResidueInd();
-        calculateFragment();
-        updateLosses();
+	resetFragment();
     }
 
     void ModifiedPeptide::FragmentGraph::incrSignature () {
@@ -490,6 +473,28 @@ namespace ptmscoring {
 
     bool ModifiedPeptide::FragmentGraph::isSignatureEnd () {
         return n_mods_outstanding > 0;
+    }
+
+    void ModifiedPeptide::FragmentGraph::resetFragment () {
+        // Intialize running state trackers
+        // Makes sure enough space is available and
+        // clears away any old data.
+        size_t peptide_size = modified_peptide->peptide.size();
+        running_sum.reserve(peptide_size);
+        running_sum.clear();
+
+        running_sequence.reserve(peptide_size);
+        running_sequence.clear();
+
+        running_loss_count.reserve(peptide_size);
+        running_loss_count.clear();
+        neutral_loss_stack.clear();
+        neutral_loss_iter.reset(neutral_loss_stack, 2);
+
+        // Reset to first step
+        resetResidueInd();
+        calculateFragment();
+        updateLosses();
     }
 
     void ModifiedPeptide::FragmentGraph::incrFragment () {

--- a/pyascore/ptm_scoring/cpp/ModifiedPeptide.h
+++ b/pyascore/ptm_scoring/cpp/ModifiedPeptide.h
@@ -100,6 +100,7 @@ namespace ptmscoring {
             void resetIterator();
             void incrSignature();
             bool isSignatureEnd();
+	    void resetFragment();
             void incrFragment();
             bool isFragmentEnd();
             bool isLoss();

--- a/test/test_modified_peptide_container.py
+++ b/test/test_modified_peptide_container.py
@@ -133,6 +133,8 @@ class TestPyModifiedPeptide(unittest.TestCase):
             b_graph.reset_iterator()
             b_graph.incr_signature()
             test(b_graph, c, np.array([71.03711, 158.06914 , 289.10963, 470.12364]))
+            b_graph.reset_fragment()
+            test(b_graph, c, np.array([71.03711, 158.06914 , 289.10963, 470.12364]))
 
             # Test c fragments
             c_graph = pep.get_fragment_graph("c", c)
@@ -145,6 +147,8 @@ class TestPyModifiedPeptide(unittest.TestCase):
             # Second signature, from beginning
             c_graph.reset_iterator()
             c_graph.incr_signature()
+            test(c_graph, c, np.array([88.06365, 175.09568, 306.13617, 487.15019]))
+            c_graph.reset_fragment()
             test(c_graph, c, np.array([88.06365, 175.09568, 306.13617, 487.15019]))
 
             # Test y fragments
@@ -159,6 +163,8 @@ class TestPyModifiedPeptide(unittest.TestCase):
             y_graph.reset_iterator()
             y_graph.incr_signature()
             test(y_graph, c, np.array([146.105525, 247.15320, 378.19369, 545.192056]))
+            y_graph.reset_fragment()
+            test(y_graph, c, np.array([146.105525, 247.15320, 378.19369, 545.192056]))
 
             # Test z fragments
             z_graph = pep.get_fragment_graph("z", c)
@@ -172,8 +178,10 @@ class TestPyModifiedPeptide(unittest.TestCase):
             z_graph.reset_iterator()
             z_graph.incr_signature()
             test(z_graph, c, np.array([129.07897, 230.12665, 361.16714, 528.16550]))
+            z_graph.reset_fragment()
+            test(z_graph, c, np.array([129.07897, 230.12665, 361.16714, 528.16550]))
 
-            # Test z fragments
+            # Test Z fragments
             z_graph = pep.get_fragment_graph("Z", c)
             # First signature all the way through
             test(z_graph, c, np.array([130.086795, 311.100805, 442.141295, 529.173325]))
@@ -184,6 +192,8 @@ class TestPyModifiedPeptide(unittest.TestCase):
             # Second signature, from beginning
             z_graph.reset_iterator()
             z_graph.incr_signature()
+            test(z_graph, c, np.array([130.086795, 231.134475, 362.174965, 529.173325]))
+            z_graph.reset_fragment()
             test(z_graph, c, np.array([130.086795, 231.134475, 362.174965, 529.173325]))
 
     def test_fragment_incr_terminal(self):

--- a/test/test_modified_peptide_container.py
+++ b/test/test_modified_peptide_container.py
@@ -104,7 +104,36 @@ class TestPyModifiedPeptide(unittest.TestCase):
         true_z_masses = [130.08680, 277.15521, 406.19780, 493.22983, 580.26186,
                          747.26022, 914.25858, 1001.29061, 1072.32772]
         test(z_graph, true_z_masses)
-        
+
+    def test_iterator(self):
+        pep = PyModifiedPeptide("STY", 79.966331)
+
+        # Test mode == "all"
+        pep.consume_peptide("ASMTK", 1)
+        b_graph = pep.get_fragment_graph("b", 1)
+        true_sig_list = [[1, 0], [0, 1]]
+        true_frag_list = [np.array([71.03711 , 238.03547, 369.07596, 470.12364]),
+                          np.array([71.03711, 158.06914 , 289.10963, 470.12364])]
+        for graph, true_sig, true_frags in zip(b_graph.iter_permutations(), true_sig_list, true_frag_list):
+            self.assertTrue(np.all(graph.get_signature() == true_sig))
+            for (pred_frag, label), mass in zip(graph.iter_fragments(), true_frags):
+                self.assertTrue(
+                    np.isclose(pred_frag, mass + 1.007825, rtol=1e-6, atol=0)
+                )
+
+        # Test mode == "reduced"
+        pep.consume_peptide("ASMTK", 1)
+        b_graph = pep.get_fragment_graph("b", 1, mode="reduced")
+        true_sig_list = [[1, 0], [0, 1]]
+        true_frag_list = [np.array([71.03711 , 238.03547, 369.07596, 470.12364]),
+                          np.array([158.06914 , 289.10963, 470.12364])]
+        for graph, true_sig, true_frags in zip(b_graph.iter_permutations(), true_sig_list, true_frag_list):
+            self.assertTrue(np.all(graph.get_signature() == true_sig))
+            for (pred_frag, label), mass in zip(graph.iter_fragments(), true_frags):
+                self.assertTrue(
+                    np.isclose(pred_frag, mass + 1.007825, rtol=1e-6, atol=0)
+                )
+
     def test_fragment_incr(self):
         pep = PyModifiedPeptide("STY", 79.966331)
         


### PR DESCRIPTION
This PR is to enhance the iterator functionality of PyModifiedPeptide in the Python API as detailed in #33. Users will be able to iterate over signatures and the underlying fragments with much more ease. This PR also adds a brief introduction to using this class in Python. As the class improves, I want to add even more detailed information, or even add a new page which is entitled `building a scoring pipeline`.