### PR TITLE
Raise minimum numpy version to avoid binary incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel", "numpy>=1.19.5", "Cython>=0.29.21"]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel", "numpy>=1.22.0", "Cython>=0.29.21"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    numpy>=1.19.5
+    numpy>=1.22.0
     scipy>=1.5.4
     pandas>=1.1.5
     tqdm>=4.64.0


### PR DESCRIPTION
This PR addresses issue #38, which mentions binary incompatibility. It looks like compilation is occurring with numpy >= 1.23.0. At some point numpy seems to have changed some defaults. As a hot fix, I am raising the minimum numpy version so that users don't get this error.